### PR TITLE
Fixes issues with arrays for ids

### DIFF
--- a/app/funcs/rock.php
+++ b/app/funcs/rock.php
@@ -45,13 +45,13 @@ function rock_array_sort(array $array, $key = null, $asc = true) {
 	}
 	else {
 		$GLOBALS["ROCK_ARRAY_SORT_KEY_" . nil] = $key;
-		uasort($array, 
+		uasort($array,
 			$asc ? create_function('$p1,$p2', '$key=$GLOBALS["ROCK_ARRAY_SORT_KEY_" . nil];$p1=rock_array_get($p1,$key);$p2=rock_array_get($p2,$key);if ($p1>$p2){return 1;}elseif($p1==$p2){return 0;}else{return -1;}')
 			:
 			create_function('$p1,$p2', '$key=$GLOBALS["rock_ARRAY_SORT_KEY_" . nil];$p1=rock_array_get($p1,$key);$p2=rock_array_get($p2,$key);if ($p1<$p2){return 1;}elseif($p1==$p2){return 0;}else{return -1;}')
 		);
 		unset($GLOBALS["ROCK_ARRAY_SORT_KEY_" . nil]);
-	}	
+	}
 	return $array;
 }
 
@@ -97,10 +97,12 @@ function rock_real_id($id) {
 				return new MongoInt32($value);
 			case "MongoInt64":
 				return new MongoInt64($value);
+			case "encoded":
+				return json_decode(base64_decode($value));
 		}
 		return;
 	}
-	
+
 	if (is_numeric($id)) {
 		return floatval($id);
 	}
@@ -122,7 +124,13 @@ function rock_id_string($id) {
 	if (is_object($id)) {
 		return "rid_" . get_class($id) . ":" . $id->__toString();
 	}
-	return "rid_" . gettype($id) . ":" . $id;
+
+	if (is_scalar($id)) {
+		return "rid_" . gettype($id) . ":" . $id;
+	} else {
+		// Handle non-scalar ids
+		return "rid_encoded:" . base64_encode(json_encode($id));
+	}
 }
 
 /**
@@ -165,7 +173,7 @@ function rock_load_languages() {
 }
 
 /**
- * Get current path of theme 
+ * Get current path of theme
  *
  * @return string
  * @since 1.1.0


### PR DESCRIPTION
Arrays causes PHP notice: "Notice: Array to string conversion in app/funcs/rock.php on line 125". 
This fix detects (in rock_id_string) if ID is not scalar, encodes it (json & base 64) and prefixes it with "rid_encoded:". To handle this, there a little change in rock_real_id() that handles new "encoded" type.

Appologies if I've manage to brake anything with this -- I don't have that much experience with rockmongo internals.
