### PR TITLE
Fixing the Auth with Pecl 1.3.*+ and Control Auth

### DIFF
--- a/app/models/MServer.php
+++ b/app/models/MServer.php
@@ -244,7 +244,7 @@ class MServer {
 				$options["password"] = $password;
 				$options["db"] = $db;
 			}
-			if($this->_controlAuth) {
+			if($this->_controlAuth && !empty($this->_mongoUser) && !empty($this->_mongoPass) && !empty($this->_mongoDb)) {
 				$options["username"] = $this->_mongoUser;
 				$options["password"] = $this->_mongoPass;
 				$options["db"] = $this->_mongoDb;


### PR DESCRIPTION
Hello

Version 1.1.5 wasn't still authenticating correctly for me and I decided to look into the code and fix the issue myself

The result is a simple addition to the MServer.php file enabling control Authentication to work (not only mongodb authentication)

Stefano
