### PR TITLE
added MongoId Metadata to row operations line

### DIFF
--- a/js/collection.js
+++ b/js/collection.js
@@ -80,6 +80,34 @@ function changeCommand(select) {
 		$("#pageSetLabel").hide();
 		$("#fieldsAndHints").hide();
 	}
+
+    var queryBox = $('.query');
+    if(value=='modify'){
+        queryBox.removeClass('query_delete');
+        queryBox.addClass('query_modify');
+    } else if(value=='remove'){
+        queryBox.addClass('query_delete');
+        queryBox.removeClass('query_modify');
+    } else {
+        queryBox.removeClass('query_delete');
+        queryBox.removeClass('query_modify');
+    }
+}
+
+function checkSubmitQuery(){
+    var method = $('select[name=command]').val(),
+        isChangeQuery = false;
+    if(method=='modify'){
+        isChangeQuery = true;
+    }
+    if(method=='remove'){
+        isChangeQuery = true;
+    }
+
+    if(isChangeQuery===true){
+        return confirm('Do you really want to run the query in "'+(method.toUpperCase())+'" mode?');
+    }
+    return true;
 }
 
 //switch html and text

--- a/themes/default/css/global.css
+++ b/themes/default/css/global.css
@@ -35,6 +35,9 @@ img {border:0}
 .query {background-color:#eeefff}
 .field_orders p { height:14px; margin-top:0 }
 
+.query_modify {background-color:#eeef99}
+.query_delete {background-color:#FFECEB}
+
 /** top **/
 .top {border-bottom:1px #666 solid; background-color:#ccc; }
 .top select { height:18px; background-color:#ccc; border:0 }

--- a/themes/default/views/collection/index.php
+++ b/themes/default/views/collection/index.php
@@ -80,7 +80,7 @@ currentFields.push("<?php h(addslashes($field));?>");
 	</tr>
 	<tr>
 		<td colspan="2">
-			<input type="submit" value="<?php hm("submit_query"); ?>"/> 
+			<input type="submit" onclick="return checkSubmitQuery(this);" value="<?php hm("submit_query"); ?>"/>
 			<input type="button" value="<?php hm("explain"); ?>" onclick="explainQuery(this.form)" /> 
 			<input type="button" value="<?php hm("clear_conditions"); ?>" onclick="window.location='<?php h(url("collection.index", array( "db"=>$db, "collection" => $collection, "format" => xn("format") ))); ?>'"/>
 			[<a href="http://rockmongo.com/wiki/queryExamples?lang=en_us" target="_blank">Query Examples</a>]


### PR DESCRIPTION
i added some metadata from the mongoid class to the action bar of every row
this information are available since PECL mongo >= 1.0.11
- http://de.php.net/manual/en/mongoid.getinc.php
- http://de.php.net/manual/en/mongoid.getpid.php
- http://de.php.net/manual/en/mongoid.gettimestamp.php

i added checks for every method so that older mongo extension should work but just do not show the data

i found this quite usefull, for example when there is no creation timestamp in a document

Preview:
![rockmongopatch](https://f.cloud.github.com/assets/85796/927673/93cf6810-ffa4-11e2-84e2-601044e0a621.PNG)
