### PR TITLE
Moved config.php to config-sample.php, gitignored the actual config.php.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-
 .buildpath
-
 .project
-
 .settings/org.eclipse.php.core.prefs
-
 .DS_Store
+/config.php

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,7 +4,8 @@ Installation
 2. Install MongoDB PHP driver (http://us.php.net/manual/en/mongo.installation.php)
 3. Download the package from http://rockmongo.com/downloads
 4. Unzip the files into your disk, under root of your site
-5. Open the config.php with your convenient editor, change host, port, admins and so on to yours
+5. Open the config-sample.php with your convenient editor, change host, port,
+   admins and so on to yours. Save this file as config.php.
 6. Visit the index.php in your browser, for example: http://localhost/rockmongo/index.php
 7. Login with admin username and password, which is set "admin" and "admin" as default
 8. Play with your MongoDBs!

--- a/config-sample.php
+++ b/config-sample.php
@@ -3,6 +3,9 @@
  * RockMongo configuration
  *
  * Defining default options and server configuration
+ *
+ * Copy config-sample.php > config.php and make your changes to the config.php.
+ *
  * @package rockmongo
  */
  
@@ -50,5 +53,3 @@ $MONGO["servers"][$i]["mongo_port"] = "27017";
 $MONGO["servers"][$i]["control_users"]["admin"] = "password";
 $i ++;
 **/
-
-?>

--- a/index.php
+++ b/index.php
@@ -30,7 +30,11 @@ ini_set("mongo.long_as_object", 1);
 /**
 * Initializing configuration files and RockMongo
 */
-require "config.php";
+if (file_exists("config.php")) {
+    require "config.php";
+} else {
+    require "config-sample.php";
+}
 require "rock.php";
 rock_check_version();
 rock_init_lang();


### PR DESCRIPTION
This PR gitignores the `config.php` and moves the default configuration to `config-sample.php`. The objective is to avoid configuration override if the user does an upgrade from the repository (as we do), while still providing convenient way to jumpstart using rockmongo.
