### PR TITLE
Added mixed mode highlighting for best of both worlds speed improvement

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+v1.1.7 - 2014-02-12
+* Added mixed-mode highlighting
+
+v1.1.6 - 2013
+* Highlighting now optional
+
 v1.1.5 - 2012-12-20
 * Fix authenticate with php_mongo >= 1.3.0
 

--- a/app/classes/BaseController.php
+++ b/app/classes/BaseController.php
@@ -211,6 +211,7 @@ class BaseController extends RExtController {
 		$exportor = new VarExportor($this->_mongo->selectDB("admin"), $var);
 		$varString = null;
 		$highlight = true;
+		$mixed = false;
 		switch ($this->_server->docsRender()) {
 			case "default":
 				$varString = $exportor->export($format, $label);
@@ -219,6 +220,15 @@ class BaseController extends RExtController {
 				$varString = $exportor->export($format, false);
 				$label = false;
 				$highlight = false;
+				break;
+			case "mixed":
+				$varString = $exportor->export($format, false);
+				if (strlen($varString) > $this->_server->docsRenderLimit())
+					$highlight = false;
+				else
+					$highlight = true;
+				$label = false;
+				$mixed = true;
 				break;
 			default:
 				$varString = $exportor->export($format, $label);

--- a/app/models/MServer.php
+++ b/app/models/MServer.php
@@ -22,6 +22,7 @@ class MServer {
 	
 	private $_docsNatureOrder = false;
 	private $_docsRender = "default";
+	private $_docsRenderLimit = 2000;
 	
 	/**
 	 * the server you are operating
@@ -94,6 +95,9 @@ class MServer {
 					break;
 				case "docs_render":
 					$this->_docsRender = $value;
+					break;
+				case "docs_render_limit":
+					$this->_docsRenderLimit = $value;
 					break;
 			}
 		}
@@ -256,17 +260,17 @@ class MServer {
 	/**
 	 * Set documents highlight render
 	 * 
-	 * @param string $render can be "default" or "plain"
+	 * @param string $render can be "default", "plain" or "mixed"
 	 * @since 1.1.6
 	 */
 	public function setDocsRender($render) {
-		$renders = array( "default", "plain" );
+		$renders = array( "default", "plain", "mixed" );
 		
 		if (in_array($render, $renders)) {
 			$this->_docsRender = $render;
 		}
 		else {
-			exit("docs_render should be either 'default' or 'plain'");
+			exit("docs_render should be 'default', 'plain' or 'mixed'");
 		}
 	}
 	
@@ -278,6 +282,16 @@ class MServer {
 	 */
 	public function docsRender() {
 		return $this->_docsRender;
+	}
+	
+	/**
+	 * Get documents highlight render limit
+	 * 
+	 * @return int
+	 * @since 1.1.7
+	 */
+	public function docsRenderLimit() {
+		return $this->_docsRenderLimit;
 	}
 	
 	public function auth($username, $password, $db = "admin") {

--- a/config.php
+++ b/config.php
@@ -36,7 +36,8 @@ $MONGO["servers"][$i]["ui_hide_collections"] = "";//collections to hide
 $MONGO["servers"][$i]["ui_hide_system_collections"] = false;//whether hide the system collections
 
 //$MONGO["servers"][$i]["docs_nature_order"] = false;//whether show documents by nature order, default is by _id field
-//$MONGO["servers"][$i]["docs_render"] = "default";//document highlight render, can be "default" or "plain"
+//$MONGO["servers"][$i]["docs_render"] = "mixed";//document highlight render, can be "default", "plain" or "mixed"
+//$MONGO["servers"][$i]["docs_render_limit"] = 2000; //in "mixed" mode, documents smaller than this size will highlighted, rest in plain.
 
 $i ++;
 

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
 /**
 * Defining version number and enabling error reporting
 */
-define("ROCK_MONGO_VERSION", "1.1.6");
+define("ROCK_MONGO_VERSION", "1.1.7");
 
 error_reporting(E_ALL);
 


### PR DESCRIPTION
Fixed issue #9

Added `"mixed"` mode for `docs_render` for when you are working with both small and large documents.
This will color-code (AKA highlight) documents smaller than `docs_render_limit`, and leave the larger ones as  `"plain"`.
