### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:5-apache
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      build-essential \
+      php5-dev \
+  && \
+  pecl channel-update pecl.php.net && \
+  pecl install mongo && \
+  rm -vrf /build /tmp/pear && \
+  echo "extension=mongo.so" > /usr/local/etc/php/conf.d/mongo.ini && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y autoremove --purge \
+      automake \
+      autotools-dev \
+      bsdmainutils \
+      build-essential \
+      php5-dev \
+      psmisc \
+  && \
+  apt-get autoclean && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /var/log/apt/*
+
+ADD . /var/www/html


### PR DESCRIPTION
Docker image build file.
How to test:
```
$ docker build -t rockmongo .
$ docker run -d --name rockmongo -p 80:80 rockmongo
$ docker run -d --name mongodb-test-server --net=container:rockmongo mongod --nojournal --noprealoc
```
Also, I encourage project maintainers to create an official image on Docker Hub. I'll gladly help to push this formward. The best option would be to create an automated build, linked to Github source repo which will trigger new image builds on each commit.
As soon as it is OK, we can figure out a way to make it work via Docker links, so no there would be no need to share container network stack or modify ```config.php```. This would be easily achieved via an environment variables aware ```config.php``` version file.