### PR TITLE
Split import js file

### DIFF
--- a/app/controllers/db.php
+++ b/app/controllers/db.php
@@ -279,7 +279,7 @@ class DbController extends BaseController {
 						$body = '';
 					} else {
 						$body = $_body;
-						unset $_body;
+						unset($_body);
 					}
 				}
 

--- a/app/controllers/db.php
+++ b/app/controllers/db.php
@@ -303,7 +303,7 @@ class DbController extends BaseController {
 						}
 
 						if (!$is_ok) {
-							$ret["ok"] = false
+							$ret["ok"] = false;
 							$ret["errmsg"] = $error_str;
 						}
 

--- a/app/controllers/db.php
+++ b/app/controllers/db.php
@@ -238,7 +238,7 @@ class DbController extends BaseController {
 					ob_end_clean();
 					header("Content-type: application/x-gzip");
 					header("Content-Disposition: attachment; filename=\"{$prefix}.gz\"");
-					echo gzcompress($this->contents, 9);
+					echo gzencode($this->contents, 9);
 					exit();
 				}
 				else {
@@ -268,12 +268,19 @@ class DbController extends BaseController {
 				$tmp = $_FILES["json"]["tmp_name"];
 
 				//read file by it's format
-				$body = "";
+				$body = file_get_contents($tmp);
 				if (preg_match("/\\.gz$/", $_FILES["json"]["name"])) {
-					$body = gzuncompress(file_get_contents($tmp));
-				}
-				else {
-					$body = file_get_contents($tmp);
+					$_body = @gzdecode($body);
+					if (!$_body) {
+						$_body = @gzuncompress($body);
+					}
+					if (!$_body) {
+						$this->error = "Can't decompress file!";
+						$body = '';
+					} else {
+						$body = $_body;
+						unset $_body;
+					}
 				}
 
 				//check format
@@ -303,7 +310,7 @@ class DbController extends BaseController {
 						}
 
 						if (!$is_ok) {
-							$ret["ok"] = false;
+							$ret["ok"] = 0;
 							$ret["errmsg"] = $error_str;
 						}
 

--- a/app/controllers/db.php
+++ b/app/controllers/db.php
@@ -291,6 +291,17 @@ class DbController extends BaseController {
 					if ($split_js) {
 
 						$body = explode('db.getCollection(', $body);
+
+						function filter_js_chunk($item) {
+							if (strpos($item, ').insert({') !== false) {
+								return true;
+							}
+							return false;
+						}
+
+						$body = array_filter($body, "filter_js_chunk");
+
+
 						$chunks = array_chunk($body, $split_max);
 
 						$is_ok = true;

--- a/app/controllers/db.php
+++ b/app/controllers/db.php
@@ -303,7 +303,7 @@ class DbController extends BaseController {
 							$ret = $this->_mongo->selectDB($this->db)->execute('function (){ ' . $chunk_str . ' }');
 
 							if (!$ret["ok"]) {
-								$error_str .= $ret["errmsg"] . PHP_EOL;
+								$error_str .= $ret["errmsg"] . '<br>Chunk with error:<br>' . PHP_EOL . $chunk_str . PHP_EOL;
 								$is_ok = false;
 							}
 

--- a/themes/default/views/db/dbImport.php
+++ b/themes/default/views/db/dbImport.php
@@ -12,7 +12,13 @@ window.parent.frames["left"].location.reload();
 
 <form method="post" enctype="multipart/form-data">
 <input type="hidden" name="format" value="js"/>
+
 JS File: <input type="file" style="width:400px" name="json"/><br/>
+
+<input type="hidden" name="split_js" value="0"/>
+<label>Do split JS File by chunks:</label> <input type="checkbox" name="split_js" value="1"/><br/>
+<label>Max documents in chunk:</label> <input type="numeric" name="split_max" value="1000"/><br/>
+
 <input type="submit" value="<?php hm("import"); ?>"/>
 </form>
 

--- a/themes/default/views/db/dbImport.php
+++ b/themes/default/views/db/dbImport.php
@@ -14,10 +14,12 @@ window.parent.frames["left"].location.reload();
 <input type="hidden" name="format" value="js"/>
 
 JS File: <input type="file" style="width:400px" name="json"/><br/>
+Support gzipped (.js.gz) files.<br/><br/>
 
 <input type="hidden" name="split_js" value="0"/>
 <label>Do split JS File by chunks:</label> <input type="checkbox" name="split_js" value="1"/><br/>
 <label>Max documents in chunk:</label> <input type="numeric" name="split_max" value="1000"/><br/>
+Useful if file more than 4mb (2.x mongo) or 16mb (3.x mongo).<br/>
 
 <input type="submit" value="<?php hm("import"); ?>"/>
 </form>

--- a/themes/default/views/db/dbImport.php
+++ b/themes/default/views/db/dbImport.php
@@ -17,7 +17,7 @@ JS File: <input type="file" style="width:400px" name="json"/><br/>
 Support gzipped (.js.gz) files.<br/><br/>
 
 <input type="hidden" name="split_js" value="0"/>
-<label>Do split JS File by chunks:</label> <input type="checkbox" name="split_js" value="1"/><br/>
+<label for="import_js_split">Do split JS File by chunks:</label> <input id="import_js_split" type="checkbox" name="split_js" value="1"/><br/>
 <label>Max documents in chunk:</label> <input type="numeric" name="split_max" value="1000"/><br/>
 Useful if file more than 4mb (2.x mongo) or 16mb (3.x mongo).<br/>
 

--- a/themes/default/views/db/dbImport.php
+++ b/themes/default/views/db/dbImport.php
@@ -18,7 +18,12 @@ Support gzipped (.js.gz) files.<br/><br/>
 
 <input type="hidden" name="split_js" value="0"/>
 <label for="import_js_split">Do split JS File by chunks:</label> <input id="import_js_split" type="checkbox" name="split_js" value="1"/><br/>
-<label>Max documents in chunk:</label> <input type="numeric" name="split_max" value="1000"/><br/>
+<label>Max documents in chunk:</label> <input id="import_js_split_max" type="range" name="split_max" min="1" max="50000" step="1" value="1000"/><span id="split_max_value">1000</span><br/>
+<script language="javascript">
+$('#import_js_split_max').change(function(){
+	$('#split_max_value').html($(this).val());
+});
+</script>
 Useful if file more than 4mb (2.x mongo) or 16mb (3.x mongo).<br/>
 
 <input type="submit" value="<?php hm("import"); ?>"/>


### PR DESCRIPTION
Collection dump was created by rockmongo itself into .js file.
File is 16.5 Mb uncompresed.

RockMongo tries to execute it at once. And fails.

We should break file into pieces (number of them?) and execute step-by-step.
Could use params:

do split (bool)
max in one query (int)